### PR TITLE
build: ensure npm install before build in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,9 @@ jobs:
           experimental: true
 
       - name: Build
-        run: mise run build
+        run: |
+          npm install
+          mise run build
 
       - id: inputs
         uses: simenandre/setup-inputs@v1


### PR DESCRIPTION
This change adds 'npm install' before 'mise run build' in the publish workflow to ensure Node.js dependencies are installed, preventing potential build failures in CI.